### PR TITLE
fixed a bug when unsupported content is downloaded; when one of the f…

### DIFF
--- a/src/main/java/com/twou/offline/OfflineManager.kt
+++ b/src/main/java/com/twou/offline/OfflineManager.kt
@@ -58,9 +58,13 @@ class OfflineManager internal constructor() : CoroutineScope {
     }
 
     fun addOfflineDownloaderCreator(creator: BaseOfflineDownloaderCreator) {
-        if (mOfflineUnsupportedRepository.isUnsupported(creator.getKeyOfflineItem().key)) return
         if (mCreatorList.contains(creator)) return
         mCreatorList.add(creator)
+
+        if (mOfflineUnsupportedRepository.isUnsupported(creator.getKeyOfflineItem().key)) {
+            updateOfflineManagerState()
+            return
+        }
 
         setItemAdded(creator.getKeyOfflineItem().key)
 

--- a/src/main/java/com/twou/offline/activity/DownloadQueueActivity.kt
+++ b/src/main/java/com/twou/offline/activity/DownloadQueueActivity.kt
@@ -45,13 +45,13 @@ class DownloadQueueActivity : AppCompatActivity() {
                 return@onEach
             }
             mDownloadQueueAdapter?.setData(it.items)
+            updatePauseResumeState()
         }.launchIn(lifecycleScope)
     }
 
     override fun onDestroy() {
         mOfflineListener?.let { mOfflineManager.removeListener(it) }
         mIOfflineNetworkChangedListener?.let { Offline.removeNetworkListener(it) }
-        mViewModel.onDestroy()
         super.onDestroy()
     }
 

--- a/src/main/java/com/twou/offline/util/BaseOfflineUtils.kt
+++ b/src/main/java/com/twou/offline/util/BaseOfflineUtils.kt
@@ -34,7 +34,7 @@ class BaseOfflineUtils {
             val file = context.getExternalFilesDir(null) ?: return true
             val freeSpace = file.freeSpace
             OfflineLogs.d("BaseOfflineUtils", "free space is $freeSpace")
-            return freeSpace <= 104857600
+            return freeSpace <= 314572800
         }
 
         @JvmStatic

--- a/src/main/java/com/twou/offline/util/OfflineDownloaderUtils.kt
+++ b/src/main/java/com/twou/offline/util/OfflineDownloaderUtils.kt
@@ -27,7 +27,7 @@ object OfflineDownloaderUtils {
 
         fileName = fileName.replace("?", "").replace(":", "")
             .replace("%", "").replace(" ", "")
-            .replace(",", "")
+            .replace(",", "").replace("—", "")
 
         if (isIncorrectFilename(fileName)) {
             fileName = renameFilePathWith(fileName, "")

--- a/src/main/java/com/twou/offline/viewmodel/DownloadQueueViewModel.kt
+++ b/src/main/java/com/twou/offline/viewmodel/DownloadQueueViewModel.kt
@@ -24,17 +24,14 @@ class DownloadQueueViewModel : ViewModel() {
                 })
             }
         }
-
-        override fun onItemDownloaded(key: String) {
-            onItemRemoved(key)
-        }
     }
 
     init {
         offlineManager.addListener(downloadListener)
     }
 
-    fun onDestroy() {
+    override fun onCleared() {
+        super.onCleared()
         offlineManager.removeListener(downloadListener)
     }
 }

--- a/src/main/res/values-night/colors.xml
+++ b/src/main/res/values-night/colors.xml
@@ -2,7 +2,7 @@
 <resources>
     <color name="offlineColorPrimary">#fff</color>
     <color name="offlineColorPrimaryDark">#0F0F0F</color>
-    <color name="offlineColorDownloadPanel">#272727</color>
+    <color name="offlineColorDownloadPanel">#191919</color>
     <color name="offlineColorDownloadPanelLine">#272727</color>
     <color name="offlineColorDivider">#68696A</color>
     <color name="offlineColorToolbar">#181818</color>


### PR DESCRIPTION
…iles (pdf) doesn't open in Downloads; when download panel with unsupported content disappears after the app unloads from memory; when a content was downloaded without video after Internet interruptions; when unable to delete a content from Download Queue after rotation device to landscape orientation; when the app crashes when phone memory is full; when no “Resume all” button in Download Queue when download paused from Coursework;